### PR TITLE
Changes back to orginal handling of find values

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,14 +203,14 @@ var proxy = superData.proxy.memory({
 
 ### Memory proxy's improved find feature
 
-Using memory proxy you can pass find values as array elements to combine filters. This way you can give negation of search conditions (search words) too.
+Using memory proxy you can pass find values as array elements to combine filters.
 
-Calling memory proxy's read function passing a 'find' property in its config object will trigger filtering on proxy's data. Every property of 'find' object refers to properties of data. These properties should contain search strings or regular expressions, but memory proxy can handle search string or regular expression arrays as multiple filter conditions. Starting a filter element with '-' character means negation of matching filter string. That condition matches elements which doesn't contain filter string specified after '-'.
+Calling memory proxy's read function passing a 'find' property in its config object will trigger filtering on proxy's data. Every property of 'find' object refers to properties of data. These properties should contain search strings or regular expressions, but memory proxy can handle search string or regular expression arrays as multiple filter conditions.
 
 ```javascript
 memoryProxy.read({
 	find: {
-		findField: ["word1", "some string 2", "/tag[0-9]+/i", "-word3"]
+		findField: ["word1", "some string 2", "/tag[0-9]+/i"]
 	}
 },
 {},
@@ -219,7 +219,7 @@ function(err, response) {
 });
 ```
 
-In the example above, we set filter to data of memory proxy. Filter matches elements having a findField property containing "word1", "some string 2", matching to regular expression "/tag[0-9]+/i" (case-insensitive "tag" followed by numbers) and not containing "word3". Memory proxy's read function calls callback with matching elements in "response" parameter's "items" property.
+In the example above, we set filter to data of memory proxy. Filter matches elements having a findField property containing "word1", "some string 2" and matching to regular expression "/tag[0-9]+/i" (case-insensitive "tag" followed by numbers). Memory proxy's read function calls callback with matching elements in "response" parameter's "items" property.
 
 ### Ajax proxy
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.16",
+  "version": "0.1.17",
   "name": "superdata",
   "description": "A ligth weight data layer module motivated by extjs' data layer. It can be used with any client-side framework.",
   "main": "src/superData.js",

--- a/spec/proxy/memorySpec.js
+++ b/spec/proxy/memorySpec.js
@@ -540,36 +540,6 @@ describe("memory proxy", function() {
 				
 			});
 
-			it("has to except elements starting with '-' character in filter word if string array is given", function() {
-				memoryProxy.read({
-					find: {
-						findField: ["-tag1", "tag2"]
-					}
-				},
-				{},
-				function(err, response) {
-					expect(Array.isArray(response.items)).toBe(true);
-					expect(response.items.length).toBe(1);
-					expect(response.count).toBe(1);
-					expect(response.items[0]).toEqual({ id: "id4", findField: "tag2 tag4"});
-				});
-			});
-
-			it("has to except elements starting with '-' character in filter word if regexp array is given", function() {
-				memoryProxy.read({
-					find: {
-						findField: ["-tag1", "/t[a-z]+g2/i"]
-					}
-				},
-				{},
-				function(err, response) {
-					expect(Array.isArray(response.items)).toBe(true);
-					expect(response.items.length).toBe(1);
-					expect(response.count).toBe(1);
-					expect(response.items[0]).toEqual({ id: "id4", findField: "tag2 tag4"});
-				});
-			});
-
 		});
 
 	});

--- a/src/proxy/memoryCore.js
+++ b/src/proxy/memoryCore.js
@@ -178,10 +178,6 @@ module.exports = function(dependencies) {
 			if (find && typeof find === "object") {
 				elements = elements.filter(function(item) {
 					function convertToRegExp(actItem) {
-						if (actItem.charAt(0) === "-") {
-							actItem = "^(?!.*" + actItem.substr(1) + ")";
-						}
-			
 						return (typeof actItem === "string") ? stringToRegExp(actItem) : actItem;
 					}
 


### PR DESCRIPTION
(doesn't handle negation of filter condition). Tests for this feature removed.

Memory proxy's filter array feature still documented (it was undocumented previously).
npm version incremented