### PR TITLE
Ajaxproxy's config.timeout is handled only in case of createOne opera…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.18",
+  "version": "0.1.19",
   "name": "superdata",
   "description": "A ligth weight data layer module motivated by extjs' data layer. It can be used with any client-side framework.",
   "main": "src/superData.js",

--- a/spec/proxy/ajaxHelpersSpec.js
+++ b/spec/proxy/ajaxHelpersSpec.js
@@ -121,12 +121,13 @@ describe("ajax helpers", function() {
 				};
 				var data = "data";
 				var id = "id";
-				var operationConfig = ajaxHelpers.createOperationConfig(config, id, data);
+				var operationConfig = ajaxHelpers.createOperationConfig(config, 3500, id, data);
 
 				expect(operationConfig.prop1).toBe(config.prop1);
 				expect(operationConfig.prop2).toBe(config.prop2);
 				expect(operationConfig.data).toBe(data);
 				expect(operationConfig.id).toBe(id);
+				expect(operationConfig.timeout).toBe(3500);
 
 			});
 
@@ -138,13 +139,19 @@ describe("ajax helpers", function() {
 				};
 				var data;
 				var id = "id";
-				var operationConfig = ajaxHelpers.createOperationConfig(config, id, data);
+				var operationConfig = ajaxHelpers.createOperationConfig(config, 3500, id, data);
 
 				expect(operationConfig.prop1).toBe(config.prop1);
 				expect(operationConfig.prop2).toBe(config.prop2);
 				expect(operationConfig.data).toEqual({});
 				expect(operationConfig.id).toBe(id);
 
+			});
+
+			it("should set timeout property to defaultTimeout if timeout parameter is not truthy", function() {
+				var operationConfig = ajaxHelpers.createOperationConfig({}, null);
+
+				expect(operationConfig.timeout).toBe(3000);
 			});
 
 		});

--- a/spec/proxy/ajaxSpec.js
+++ b/spec/proxy/ajaxSpec.js
@@ -140,7 +140,8 @@ describe("ajax proxy", function() {
 
 			var config = {
 				idProperty: "id",
-				operations: {}
+				operations: {},
+				timeout: 4000
 			};
 			ajaxProxy = createAjaxProxy(config);
 			data = {
@@ -169,6 +170,7 @@ describe("ajax proxy", function() {
 
 					expect(ajaxHelpers.assert).toHaveBeenCalledTimes(1);
 					expect(ajaxHelpers.createOperationConfig).toHaveBeenCalledTimes(1);
+					expect(ajaxHelpers.createOperationConfig.calls.argsFor(0)[1]).toBe(4000);
 					expect(ajaxHelpers.dispatchAjax).toHaveBeenCalledTimes(1);
 					expect(ajaxHelpers.dispatchAjax.calls.argsFor(0)[0]).toEqual({
 						queries: {
@@ -204,6 +206,7 @@ describe("ajax proxy", function() {
 
 				expect(ajaxHelpers.assert).toHaveBeenCalledTimes(1);
 				expect(ajaxHelpers.createOperationConfig).toHaveBeenCalledTimes(1);
+				expect(ajaxHelpers.createOperationConfig.calls.argsFor(0)[1]).toBe(4000);
 				expect(ajaxHelpers.dispatchAjax).toHaveBeenCalledTimes(1);
 				expect(callback).toHaveBeenCalledTimes(1);
 
@@ -221,6 +224,7 @@ describe("ajax proxy", function() {
 
 					expect(ajaxHelpers.assert).toHaveBeenCalledTimes(1);
 					expect(ajaxHelpers.createOperationConfig).toHaveBeenCalledTimes(1);
+					expect(ajaxHelpers.createOperationConfig.calls.argsFor(0)[1]).toBe(4000);
 					expect(ajaxHelpers.dispatchAjax).toHaveBeenCalledTimes(1);
 					expect(callback).toHaveBeenCalledTimes(1);
 
@@ -251,6 +255,7 @@ describe("ajax proxy", function() {
 
 					expect(ajaxHelpers.assert).toHaveBeenCalledTimes(1);
 					expect(ajaxHelpers.createOperationConfig).toHaveBeenCalledTimes(1);
+					expect(ajaxHelpers.createOperationConfig.calls.argsFor(0)[1]).toBe(4000);
 					expect(ajaxHelpers.dispatchAjax).toHaveBeenCalledTimes(1);
 					expect(callback).toHaveBeenCalledTimes(1);
 
@@ -281,6 +286,7 @@ describe("ajax proxy", function() {
 
 					expect(ajaxHelpers.assert).toHaveBeenCalledTimes(1);
 					expect(ajaxHelpers.createOperationConfig).toHaveBeenCalledTimes(1);
+					expect(ajaxHelpers.createOperationConfig.calls.argsFor(0)[1]).toBe(4000);
 					expect(ajaxHelpers.dispatchAjax).toHaveBeenCalledTimes(1);
 					expect(callback).toHaveBeenCalledTimes(1);
 

--- a/src/proxy/ajaxCore.js
+++ b/src/proxy/ajaxCore.js
@@ -5,6 +5,8 @@
 /*jslint node: true */
 "use strict";
 
+var defaultTimeout = 3000;
+
 module.exports = function(dependencies) {
 
 	if(!dependencies) {
@@ -46,6 +48,7 @@ module.exports = function(dependencies) {
 		}
 
 		var idProperty = config.idProperty;
+		var timeout = config.timeout || defaultTimeout;
 
 		var generateId = config.generateId || (function() {
 			var nextId = 0;
@@ -79,13 +82,12 @@ module.exports = function(dependencies) {
 			removeFields(data, fieldsToBeExcluded);
 
 			checkCallback(callback);
-			var actConfig = createOperationConfig(config.operations.createOne, null, data);
+			var actConfig = createOperationConfig(config.operations.createOne, timeout, null, data);
 
 			if (data.constructor === FormData) {
 				actConfig.formData = true;
 			}
 
-			actConfig.timeout = config.timeout;
 			actConfig.idProperty = idProperty;
 
 			dispatchAjax(actConfig, callback);
@@ -100,7 +102,7 @@ module.exports = function(dependencies) {
 			if (typeof queryMapping === "function") {
 				options = queryMapping(options);
 			}
-			var actConfig = createOperationConfig(config.operations.read);
+			var actConfig = createOperationConfig(config.operations.read, timeout);
 
 			for (var prop in options) {
 				actConfig.queries[prop] = options[prop];
@@ -115,7 +117,7 @@ module.exports = function(dependencies) {
 				filters = undefined;
 			}
 			checkCallback(callback);
-			var actConfig = createOperationConfig(config.operations.readOneById, id);
+			var actConfig = createOperationConfig(config.operations.readOneById, timeout, id);
 			dispatchAjax(actConfig, filters, callback);
 		}
 
@@ -127,7 +129,7 @@ module.exports = function(dependencies) {
 			removeFields(newData, fieldsToBeExcluded);
 
 			checkCallback(callback);
-			var actConfig = createOperationConfig(config.operations.updateOneById, id, newData);
+			var actConfig = createOperationConfig(config.operations.updateOneById, timeout, id, newData);
 			dispatchAjax(actConfig, filters, callback);
 		}
 
@@ -137,7 +139,7 @@ module.exports = function(dependencies) {
 				filters = undefined;
 			}
 			checkCallback(callback);
-			var actConfig = createOperationConfig(config.operations.destroyOneById, id);
+			var actConfig = createOperationConfig(config.operations.destroyOneById, timeout, id);
 			dispatchAjax(actConfig, filters, callback);
 		}
 

--- a/src/proxy/ajaxHelpers.js
+++ b/src/proxy/ajaxHelpers.js
@@ -20,7 +20,7 @@ module.exports = function(dependencies) {
 	var request = dependencies.request;
 	var createReader = dependencies.createReader;
 	
-	function createOperationConfig(config, id, data) {
+	function createOperationConfig(config, timeout, id, data) {
 		var newConfig = {};
 
 		for (var prop in config) {
@@ -34,6 +34,7 @@ module.exports = function(dependencies) {
 		}
 
 		newConfig.id = id;
+		newConfig.timeout = newConfig.timeout || timeout || defaultTimeout;
 
 		return newConfig;
 	}


### PR DESCRIPTION
…tion. It also should be passed to read, readOneById, updateOneById, destroyOneById operations and handled correspondly as common timeout value. However, custom timeout for a single operation could be given in operation's config henceforward.

Tests written also.